### PR TITLE
Add keybinds to toggle cut mode and clearing cuts

### DIFF
--- a/scripts/mpv-lossless-cut/main.lua
+++ b/scripts/mpv-lossless-cut/main.lua
@@ -84,9 +84,13 @@ function cut_set_end(end_time)
 	log(string.format("[cut %d] Set end time: %.2fs", cut_index + 1, end_time))
 end
 
-function on_file_change()
-	cuts = {}
-	cut_index = 0
+function cut_clear()
+	local next = next
+	if next(cuts) ~= nil then
+		cuts = {}
+		cut_index = 0
+		print("Cuts cleared")
+	end
 end
 
 mp.add_key_binding('g', "cut_set_start", function() cut_set_start(mp.get_property_number("time-pos")) end)
@@ -96,9 +100,10 @@ mp.add_key_binding('G', "cut_set_start_sof", function() cut_set_start(0) end)
 mp.add_key_binding('H', "cut_set_end_eof", function() cut_set_end(mp.get_property('duration')) end)
 
 mp.add_key_binding('ctrl+G', "cut_toggle_mode", cut_toggle_mode)
+mp.add_key_binding('ctrl+H', "cut_clear", cut_clear)
 
 mp.add_key_binding('r', "cut_render", cut_render)
 
-mp.register_event("end-file", on_file_change)
+mp.register_event("end-file", cut_clear)
 
 print("mpv-lossless-cut loaded")

--- a/scripts/mpv-lossless-cut/main.lua
+++ b/scripts/mpv-lossless-cut/main.lua
@@ -19,6 +19,11 @@ function log(...)
 	mp.osd_message(...)
 end
 
+function cut_mode_toggle()
+	if options["multi_cut_mode"]=="separate" then options["multi_cut_mode"]="merge" else options["multi_cut_mode"]="separate" end
+	log(string.format("Cut mode set to \"%s\"", options["multi_cut_mode"]))
+end
+
 function cut_render()
 	if cuts[cut_key()] == nil or cuts[cut_key()]['end'] == nil then
 		log("No cuts to render")
@@ -89,6 +94,8 @@ mp.add_key_binding('h', "cut_set_end", function() cut_set_end(mp.get_property_nu
 
 mp.add_key_binding('G', "cut_set_start_sof", function() cut_set_start(0) end)
 mp.add_key_binding('H', "cut_set_end_eof", function() cut_set_end(mp.get_property('duration')) end)
+
+mp.add_key_binding('ctrl+g', "cut_mode_toggle", function() cut_mode_toggle() end)
 
 mp.add_key_binding('r', "cut_render", cut_render)
 

--- a/scripts/mpv-lossless-cut/main.lua
+++ b/scripts/mpv-lossless-cut/main.lua
@@ -19,7 +19,7 @@ function log(...)
 	mp.osd_message(...)
 end
 
-function cut_mode_toggle()
+function cut_toggle_mode()
 	if options["multi_cut_mode"]=="separate" then options["multi_cut_mode"]="merge" else options["multi_cut_mode"]="separate" end
 	log(string.format("Cut mode set to \"%s\"", options["multi_cut_mode"]))
 end
@@ -95,7 +95,7 @@ mp.add_key_binding('h', "cut_set_end", function() cut_set_end(mp.get_property_nu
 mp.add_key_binding('G', "cut_set_start_sof", function() cut_set_start(0) end)
 mp.add_key_binding('H', "cut_set_end_eof", function() cut_set_end(mp.get_property('duration')) end)
 
-mp.add_key_binding('ctrl+g', "cut_mode_toggle", function() cut_mode_toggle() end)
+mp.add_key_binding('ctrl+G', "cut_toggle_mode", cut_toggle_mode)
 
 mp.add_key_binding('r', "cut_render", cut_render)
 


### PR DESCRIPTION
I switch between wanting to merge or separate cuts based on whatever file I'm editing so I made a keybind to toggle the multi-cut mode. It's also helpful to have a keybind to clear cuts on demand in case you make mistakes and realize before rendering.