### PR TITLE
Fix: only copy video and audio stream & save cut to input file's dir if output_path is set to `.` instead of cwd

### DIFF
--- a/mpv-lossless-cut.lua
+++ b/mpv-lossless-cut.lua
@@ -171,9 +171,9 @@ local function render_cut(input, outpath, start, duration, input_mtime)
 		tostring(duration),
 		"-i",
 		input,
-		-- copy video stream
+		-- copy video stream if present
 		"-map",
-		"0:v",
+		"0:v?",
 		-- copy audio stream if present
 		"-map",
 		"0:a?",
@@ -227,9 +227,12 @@ local function merge_cuts(temp_dir, filepaths, outpath, input_mtime)
 		-- don't re-encode
 		"-c",
 		"copy",
-		-- copy all input streams
+		-- copy video stream if present
 		"-map",
-		"0",
+		"0:v?",
+		-- copy audio stream if present
+		"-map",
+		"0:a?",
 		outpath,
 	})
 

--- a/mpv-lossless-cut.lua
+++ b/mpv-lossless-cut.lua
@@ -171,9 +171,12 @@ local function render_cut(input, outpath, start, duration, input_mtime)
 		tostring(duration),
 		"-i",
 		input,
-		-- copy all input streams
+		-- copy video stream
 		"-map",
-		"0",
+		"0:v",
+		-- copy audio stream if present
+		"-map",
+		"0:a?",
 		-- shift timestamps so they start at 0
 		"-avoid_negative_ts",
 		"make_zero",
@@ -203,7 +206,7 @@ local function merge_cuts(temp_dir, filepaths, outpath, input_mtime)
 	local content = ""
 
 	for _, path in ipairs(filepaths) do
-			content = content .. string.format("file '%s'\n", ffmpeg_escape_filepath(path))
+		content = content .. string.format("file '%s'\n", ffmpeg_escape_filepath(path))
 	end
 
 	local file = io.open(merge_file, "w")
@@ -286,9 +289,9 @@ local function cut_render()
 	local cwd = mp.utils.getcwd()
 	local outdir
 	if options.output_dir == "." then
-			outdir = cwd
+		outdir = cwd
 	else
-			outdir = mp.utils.join_path(cwd, options.output_dir)
+		outdir = mp.utils.join_path(cwd, options.output_dir)
 	end
 
 	-- create output directory if needed

--- a/mpv-lossless-cut.lua
+++ b/mpv-lossless-cut.lua
@@ -289,11 +289,12 @@ local function cut_render()
 
 	local is_stream = input_info == nil
 
-	local cwd = mp.utils.getcwd()
 	local outdir
 	if options.output_dir == "." then
-		outdir = cwd
+		local input_path = mp.get_property("path")
+		outdir = mp.utils.split_path(input_path)
 	else
+		local cwd = mp.utils.getcwd()
 		outdir = mp.utils.join_path(cwd, options.output_dir)
 	end
 


### PR DESCRIPTION
I encountered an error while trying this script with footage recorded from my drone (DJI Mini 4 Pro), and found out it's related to the streams.

The error was:

[mpv_lossless_cut] Running ffmpeg command: ffmpeg -nostdin -loglevel error -y -ss 8.0413666666667 -t 49.516133333333 -i /home/daniel/Flybrary/Georgia/MtatsumindaPark/Orbit.MP4 -map 0 -avoid_negative_ts make_zero -c copy /home/daniel/Flybrary/Georgia/MtatsumindaPark/(cut) Orbit (8.0s - 57.6s).MP4
[mpv_lossless_cut] [mp4 @ 0x561041315c40] Could not find tag for codec none in stream #1, codec not currently supported in container
[mpv_lossless_cut] [out#0/mp4 @ 0x561041313900] Could not write header (incorrect codec parameters ?): Invalid argument

It's most likely because my drone footage also include data/subtitle stream that MP4 doesn't support directly.

I edited the script so that it only copies video stream and audio stream (if present).

This PR also includes another fix: if output_path is set to `.`, but mpv is not run through the terminal (but just through double-click through a file manager), in my Linux system cwd will be set to my home directory ~, so the cut will be saved in my home dir. Now, if output_path is set to `.` in the config, it's treated as an alias for "same dir as the input file".

Thanks for your project!