### PR TITLE
feat: lossy ffmpeg args & render+copy keybind

### DIFF
--- a/mpv-lossless-cut.conf
+++ b/mpv-lossless-cut.conf
@@ -1,3 +1,4 @@
-lossless=yes
 output_dir=.
 multi_cut_mode=separate
+lossless=yes
+lossy_ffmpeg_args=-c:v libx264 -crf 18 -preset fast -c:a aac -b:a 192k


### PR DESCRIPTION
Changes
- `lossy_ffmpeg_args` config option. Sets the arguments used for encoding when `lossless	` = false, or...
- Added `ctrl+r` hotkey for rendering a lossy cut to a temporary directory, and copies it to clipboard
